### PR TITLE
Several optimisations and bugs

### DIFF
--- a/ipproblem.py
+++ b/ipproblem.py
@@ -305,7 +305,6 @@ class IPProblem(object):
                     continue
                 v=self.succ(w-ei)
                 v_p,v_m=self.pm_split(v)
-                f=lambda vp:  self.getz(v-vp) and self.can_reduce_by(vp,vp)
                 # f=lambda vp:  self.getz(v-vp) and self.can_reduce_by(vp,v)
                 if (self.is_feasible(v_p)
                     and self.is_feasible(v_m)

--- a/ipproblem.py
+++ b/ipproblem.py
@@ -72,25 +72,28 @@ class IPProblem(object):
 
     def order(self, v, w):
         """
-        Return `1` if `v>=w`, ``-1`` in other case. 
+        Return `1` if `v>w`, `0` if `v==w`, and `-1`  if `v<w`.
         Both `v` and `w` are assumed to be vectors.
         """
         t=self.cost(v)-self.cost(w)
         if t==0:
-            assert(len(v)==len(w)) # remove this when stable.
+            # assert(len(v)==len(w)) # remove this when stable.
             for v_i,w_i in zip(v,w):
                 if v_i>w_i:
                     return 1
                 elif v_i<w_i:
                     return -1
             # If we get here, they are equal.
-            return 1
+            return 0
         else:
             return int(sign(t)) # needs to be int, so that works for cmp=order.
 
     def getz(self, v):
         """Check if v is greater or equal than zero, component-wise."""
-        return all(vi>=0 for vi in v)
+        # return all(vi>=0 for vi in v)
+        for vi in v:
+            if vi<0: return False
+        return True
 
     def is_feasible(self, y):
         """Return `True` if `y` is feasible for this problem"""
@@ -129,7 +132,7 @@ class IPProblem(object):
         p=copy(self.zero)
         m=copy(self.zero)
         for i in range(l):
-            if v[i]>0:
+            if v[i]>=0:
                 p[i]=v[i]
             else:
                 m[i]=-v[i]
@@ -160,19 +163,32 @@ class IPProblem(object):
 
     def can_reduce_by(self, v, w):
         """
-        Return true if `w` can be reduced by `v`. Here, `v` is assumed
+        Return ±1 if `±w` can be reduced by `v`, else return None. Here, `v` is assumed
         to be an “improvement vector”.
         """
-        assert(not w.is_zero())
+        # assert(not w.is_zero())
         vp,vm=self.pm_split(v)
         wp,wm=self.pm_split(w)
         if (self.getz(wp-vp) and
             self.getz(wm-vm)):
             Avp,Avm=self.pm_split(self.A*v)
-            Awp,Avm=self.pm_split(self.A*w)
-            return self.getz(Awp-Avp)
-        else:
-            return False
+            Awp,Awm=self.pm_split(self.A*w)
+            if self.getz(Awp-Avp):
+                return 1
+            # # Just return a None
+            # else:
+            #     return False
+        elif (self.getz(wm-vp) and 
+                    self.getz(wp-vm)):
+            Avp,Avm=self.pm_split(self.A*v)
+            Awp,Awm=self.pm_split(self.A*w)                    
+            if self.getz(Awm-Avp):
+                return -1
+        # # Just return None
+        #     else:
+        #         return False
+        # else:
+        #     return False
 
     def can_reduce_by_set(self, w, B):
         """
@@ -181,10 +197,9 @@ class IPProblem(object):
         vector of `B`
         """
         for (i,v) in enumerate(B):
-            if self.can_reduce_by(v,w):
-                return (i,1)
-            elif self.can_reduce_by(v,-w):
-                return (i,-1)
+            c=self.can_reduce_by(v,w)
+            if c:
+                return (i,c)
         return False
 
 
@@ -225,7 +240,7 @@ class IPProblem(object):
         while pairs:
             # verbose("Size of pairs: %s" % len(pairs), 2)
             # verbose("Size of set  : %s" % len(B), 2)
-            i,j=pairs[0]
+            i,j=pairs.pop(0)
             v,w=B[i],B[j]
             # Make sure, w is bigger than v.
             if self.order(v,w)>0:
@@ -240,7 +255,6 @@ class IPProblem(object):
                     l=len(B)-1
                     pairs+=[(i,l) for i in range(l)]
                     verbose("Added %s, now %s pairs" % (w, len(pairs)), level=1)
-            pairs.pop(0)
 
         self.minimal=B
         return B
@@ -292,9 +306,12 @@ class IPProblem(object):
                 v=self.succ(w-ei)
                 v_p,v_m=self.pm_split(v)
                 f=lambda vp:  self.getz(v-vp) and self.can_reduce_by(vp,vp)
+                # f=lambda vp:  self.getz(v-vp) and self.can_reduce_by(vp,v)
                 if (self.is_feasible(v_p)
                     and self.is_feasible(v_m)
-                    and not any(map(f, B))):
+                    and not #any(map(f, B))
+                        any(self.getz(v-vp) and self.can_reduce_by(vp,v) for vp in B)
+                    ):
                     B.append(v)
                     verbose("Added %s" % v, 1)
             l+=1


### PR DESCRIPTION
- Hard coded `getz` to not use `all`.
- In `pm_split`, don’t change sign for 0.
- `can_reduce`now returns ±1, so that you don’t have to call it twice,
  once for `w`, once for `-w`. It will only compute matrix products if
  preconditions are satisfied. Changed `can_reduce_by_set` accordingly.
- removed `lambda` function from `test_set_non_reducibles`. Fixed a bug
  in its definition, line 308.
